### PR TITLE
Make ApiAccount and ApiUser properties publicly accessible 

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "532d8b529501fb73a2455b179e0bbb6d49b652ed",
-        "version" : "1.5.3"
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     },
     {

--- a/Sources/Nakama/Models/ApiAccount.swift
+++ b/Sources/Nakama/Models/ApiAccount.swift
@@ -19,23 +19,23 @@ import Foundation
 /// A user with additional account details. Always the current user.
 public struct ApiAccount {
     /// The user object.
-    let user: ApiUser
+    public let user: ApiUser
     
     /// The custom id in the user's account.
-    let customId: String
+    public let customId: String
     
     /// The devices which belong to the user's account.
-    let devices: [Nakama_Api_AccountDevice]
+    public let devices: [Nakama_Api_AccountDevice]
     
     /// The UNIX time when the user's account was disabled/banned.
-    let disableTime: Date
+    public let disableTime: Date
     
     /// The email address of the user.
-    let email: String
+    public let email: String
     
     /// The UNIX time when the user's email was verified.
-    let VerifyTime: Date
+    public let VerifyTime: Date
     
     /// The user's wallet data.
-    let wallet: String
+    public let wallet: String
 }

--- a/Sources/Nakama/Models/User.swift
+++ b/Sources/Nakama/Models/User.swift
@@ -18,22 +18,57 @@ import Foundation
 
 /// A user in the server.
 public struct ApiUser {
+    /// The id of the user's account.
     public let id: String
+    
+    /// The Apple Sign In ID in the user's account.
     public let appleId: String
+    
+    /// A URL for an avatar image.
     public let avatarUrl: String
+    
+    /// The UNIX time when the user was created.
     public let createTime: Date
+    
+    /// The display name of the user.
     public let displayName: String
+    
+    /// Number of related edges to this user.
     public let edgeCount: Int
+    
+    /// The Facebook id in the user's account.
     public let facebookId: String
+    
+    /// The Facebook Instant Game ID in the user's account.
     public let facebookInstantGameId: String
+    
+    /// The Apple Game Center in of the user's account.
     public let gamecenterId: String
+    
+    /// The Google id in the user's account.
     public let googleId: String
+    
+    /// The language expected to be a tag which follows the BCP-47 spec.
     public let langTag: String
+    
+    /// The location set by the user.
     public let location: String
+    
+    /// Additional information stored as a JSON object.
     public let metadata: String
+    
+    /// Indicates whether the user is currently online.
     public let online: Bool
+    
+    /// The Steam id in the user's account.
     public let steamId: String
+    
+    /// The timezone set by the user.
     public let timezone: String
+    
+    /// The UNIX time when the user was last updated.
     public let updateTime: Date
+    
+    /// The username of the user's account.
     public let username: String
 }

--- a/Sources/Nakama/Models/User.swift
+++ b/Sources/Nakama/Models/User.swift
@@ -18,57 +18,22 @@ import Foundation
 
 /// A user in the server.
 public struct ApiUser {
-    /// The id of the user's account.
-    let id: String
-    
-    /// The Apple Sign In ID in the user's account.
-    let appleId: String
-    
-    /// A URL for an avatar image.
-    let avatarUrl: String
-    
-    /// The UNIX time when the user was created.
-    let createTime: Date
-    
-    /// The display name of the user.
-    let displayName: String
-    
-    /// Number of related edges to this user.
-    let edgeCount: Int
-    
-    /// The Facebook id in the user's account.
-    let facebookId: String
-    
-    /// The Facebook Instant Game ID in the user's account.
-    let facebookInstantGameId: String
-    
-    /// The Apple Game Center in of the user's account.
-    let gamecenterId: String
-    
-    /// The Google id in the user's account.
-    let googleId: String
-    
-    /// The language expected to be a tag which follows the BCP-47 spec.
-    let langTag: String
-    
-    /// The location set by the user.
-    let location: String
-    
-    /// Additional information stored as a JSON object.
-    let metadata: String
-    
-    /// Indicates whether the user is currently online.
-    let online: Bool
-    
-    /// The Steam id in the user's account.
-    let steamId: String
-    
-    /// The timezone set by the user.
-    let timezone: String
-    
-    /// The UNIX time when the user was last updated.
-    let updateTime: Date
-    
-    /// The username of the user's account.
-    let username: String
+    public let id: String
+    public let appleId: String
+    public let avatarUrl: String
+    public let createTime: Date
+    public let displayName: String
+    public let edgeCount: Int
+    public let facebookId: String
+    public let facebookInstantGameId: String
+    public let gamecenterId: String
+    public let googleId: String
+    public let langTag: String
+    public let location: String
+    public let metadata: String
+    public let online: Bool
+    public let steamId: String
+    public let timezone: String
+    public let updateTime: Date
+    public let username: String
 }


### PR DESCRIPTION
Update the ApiAccount and ApiUser structs to make all properties publicly accessible, allowing other modules to read these properties directly.